### PR TITLE
BugFix: Parallel Prevention iterator invalidation

### DIFF
--- a/Runtime/APIClient.cs
+++ b/Runtime/APIClient.cs
@@ -388,6 +388,7 @@ namespace ModIO
                                  + url);
                 return;
             }
+            APIClient._activeGetRequests.Remove(url);
 
             // - process callbacks -
             string responseBody = null;
@@ -414,8 +415,6 @@ namespace ModIO
                     }
                 }
             }
-
-            APIClient._activeGetRequests.Remove(url);
         }
 
         /// <summary>Processes the response for the given request.</summary>


### PR DESCRIPTION
Fixed a bug that could cause an iterator invalidation if a callback made an identical Get Request