### PR TITLE
correct the .git url in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The best way is to install this library as a [Git package](https://docs.unity3d.
 First, make sure that you to have Git installed and available in your system's PATH.
 After that you need to add the following line to your project's `manifest.json`:
 ```
-"com.modio.unityplugin": "https://github.com/modio/modio-unity-upm.git",
+"com.modio.unityplugin": "https://github.com/modio/modio-unity.git",
 ```
 
 It should look like this, notice the comma at the end of the line:


### PR DESCRIPTION
The error in this URL caused Unity to give me an error about credentials (suggesting that the repository is private and I should log in)

It took me a while to chase down that the error was in fact due to the old repository URL being used.