### PR TITLE
Non-windows platforms unzipping

### DIFF
--- a/ThirdParty/SharpZip/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/ThirdParty/SharpZip/src/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -3601,6 +3601,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 
 				StreamUtils.ReadFully(baseStream_, buffer, 0, nameLen);
 				string name = ZipStrings.ConvertToStringExt(bitFlags, buffer, nameLen);
+				name = ZipStrings.ReplaceBackslashes(name);
 
 				var entry = new ZipEntry(name, versionToExtract, versionMadeBy, (CompressionMethod)method)
 				{

--- a/ThirdParty/SharpZip/src/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
+++ b/ThirdParty/SharpZip/src/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
@@ -222,6 +222,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			inputBuffer.ReadRawBuffer(buffer);
 
 			string name = ZipStrings.ConvertToStringExt(flags, buffer);
+			name = ZipStrings.ReplaceBackslashes(name);
 
 			entry = new ZipEntry(name, versionRequiredToExtract, ZipConstants.VersionMadeBy, method)
 			{

--- a/ThirdParty/SharpZip/src/ICSharpCode.SharpZipLib/Zip/ZipStrings.cs
+++ b/ThirdParty/SharpZip/src/ICSharpCode.SharpZipLib/Zip/ZipStrings.cs
@@ -190,5 +190,13 @@ namespace ICSharpCode.SharpZipLib.Zip
 			=> (string.IsNullOrEmpty(str))
 				? Empty.Array<byte>()
 				: EncodingFromFlag(flags).GetBytes(str);
+
+		public static string ReplaceBackslashes(string input)
+		{
+			const char BACKSLASH = '\\';
+			if (input.Contains(BACKSLASH))
+				return input.Replace(BACKSLASH, '/');
+			return input;
+		}
 	}
 }


### PR DESCRIPTION
Zip archives created under Windows may use backslash as internal path separator. This patch works this around by replacing any backslash with regular slash.

Concerns: https://github.com/icsharpcode/SharpZipLib/issues/617